### PR TITLE
added gcloud build configurations as well as goreleaser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Resolves
+
+<Jira or Github issue reference(s)>
+
+# What
+
+<What is this PR is trying to accomplish?>
+
+# How
+
+<How is the PR designed to solve the problem?>
+
+## How to test
+
+<instructions for verifying the changes specific to this PR>
+
+# Why
+
+<Why was the final approach taken? Were alternatives considered?>
+
+# TODO
+
+<outstanding tasks before this PR is considered 'ready'>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+project_name: telemetry-oracle-agent
+before:
+  hooks:
+    - go mod download
+builds:
+  - binary: telemetry-oracle-agent
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    ignore:
+      - goos: darwin
+        goarch: 386
+archives:
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{.Tag}}-SNAPSHOT-{{.ShortCommit}}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^misc:'
+      - '^test:'
+      - '^build:'
+release:
+  github:
+    owner: racker
+    name: salus-telemetry-oracle-agent

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,9 @@
-project_name: telemetry-oracle-agent
+project_name: salus-oracle-agent
 before:
   hooks:
     - go mod download
 builds:
-  - binary: telemetry-oracle-agent
+  - binary: salus-oracle-agent
     env:
       - CGO_ENABLED=0
     goos:
@@ -39,4 +39,4 @@ changelog:
 release:
   github:
     owner: racker
-    name: salus-telemetry-oracle-agent
+    name: salus-oracle-agent

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+OS := $(shell uname -s)
+IAmGroot := $(shell whoami)
+
+.PHONY: default
+default: build
+
+.PHONY: snapshot
+snapshot:
+	goreleaser release --rm-dist --snapshot
+
+.PHONY: release
+release:
+	curl -sL https://git.io/goreleaser | bash
+
+.PHONY: build
+build:
+	go build -o salus-oracle-agent .
+
+.PHONY: install
+install: test
+	go install
+
+.PHONY: clean
+clean:
+	rm -f salus-oracle-agent
+
+.PHONY: test
+test: clean
+	go test ./...
+
+.PHONY: retest
+retest:
+	go test ./...
+
+.PHONY: test-verbose
+test-verbose: clean
+	go test -v ./...
+
+test-report-junit:
+	mkdir -p test-results
+	go test -v ./... 2>&1 | tee test-results/go-test.out
+	go get -mod=readonly github.com/jstemmer/go-junit-report
+	go-junit-report <test-results/go-test.out > test-results/report.xml
+
+.PHONY: coverage
+coverage:
+	go test -cover ./...
+
+.PHONY: coverage-report
+coverage-report:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+
+.PHONY: init-os-specific init-gotools init
+init: init-os-specific init-gotools
+
+ifeq (${OS},Darwin)
+init-os-specific:
+	-brew install goreleaser
+else
+init-os-specific:
+	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+endif
+
+init-gotools:
+	go get -mod=readonly github.com/petergtz/pegomock/...

--- a/cloudbuild-deploy.yml
+++ b/cloudbuild-deploy.yml
@@ -1,0 +1,14 @@
+steps:
+
+  # Create github release.
+  - name: goreleaser/goreleaser
+    entrypoint: /bin/sh
+    dir: /workspace
+    args: ['-c', 'git tag $TAG_NAME && goreleaser' ]
+    secretEnv: ['GITHUB_TOKEN']
+
+secrets:
+  - kmsKeyName: projects/salus-220516/locations/global/keyRings/salus-tel-oracle-agent-deploy/cryptoKeys/github-token
+    secretEnv:
+      GITHUB_TOKEN: |
+        CiQAO+30mjxK35ndt9k2N48iGdfdqH1Q7Mf6lJuUkgMNKswVfWkSUQAY+Nt/0zTHywRVKGGBMUNpZkPHrhXOW9EsXwaD6cJ0DsCPQXrSINEF4bdoCXA13zqvBEtWx3JKP9w7cTG4NK8sWYYi5aG2xDV+pTD4kfJiLQ==

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,0 +1,17 @@
+steps:
+
+  - id: GO_TEST
+    name: 'golang:1.13'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -ex
+        make init
+        make test-report-junit
+        cat test-results/report.xml
+
+  - id: UPLOAD_RESULTS
+    name: 'gcr.io/cloud-builders/gsutil'
+    args: ['cp', 'test-results/report.xml', "gs://salus-cache/salus-telemetry-oracle-agent-test-results/report-${BUILD_ID}.xml"]
+


### PR DESCRIPTION
# Resolves

This is only part of whats needed for https://jira.rax.io/browse/SALUS-692

# What

It is supposed to get this projected getting the tests and build happening in google cloud.

I did already create the triggers in gcp for watching this repo and building it/running tests.

# How

It adds the configuration files that the google cloud triggers are referencing so that it will test on branches and should build and deploy here on a tag

## How to test

When the PR is created I expect that gcp will run the tests in the PR. 

# Why

It's the same approach taken for the Envoy build process

# TODO

@terryllowery is double checking some permissions issues that he remembered from a different repo. 
