### PR TITLE
make cloudbuilds run the tests directly

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -8,8 +8,7 @@ steps:
       - |
         set -ex
         make init
-        make test-report-junit
-        cat test-results/report.xml
+        make test
 
   - id: UPLOAD_RESULTS
     name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-692

# What

Call the tests directly so that the output from them is not suppressed

# How

Alters the Make target that I am calling

## How to test

Check the build trigger in gcp once this PR is opened. 

# Why

The report that was being generated was suppressing the failures of tests in gcp. We don't really need the report here and gcp isn't rendering the HTML of the report anyway so it will be better to just directly run the tests.

# TODO

Validate that now that the PR is opened that things are running correctly in GCP.
