### PR TITLE
refactored some functions to make test failures more readable

### DIFF
--- a/envoyConnection.go
+++ b/envoyConnection.go
@@ -15,7 +15,7 @@ var retryLimit = 5
 
 
 type iconnection interface {
-	WriteToEnvoy(input []byte)
+	WriteToEnvoy(input string)
 	Retry() error
 }
 
@@ -62,13 +62,13 @@ func (c *connection) Retry() error {
 }
 
 
-func (c *connection) WriteToEnvoy(input []byte) {
+func (c *connection) WriteToEnvoy(input string) {
 	errFlag := false
 	c.mux.Lock()
 	if c.conn != nil {
 
 
-		_, err := c.conn.Write(append(input, []byte("\r\n")...))
+		_, err := c.conn.Write(append([]byte(input), []byte("\r\n")...))
 		if err != nil {
 			log.Printf("Could not write to Envoy: %s", err)
 			err := c.Retry()

--- a/envoyConnection.go
+++ b/envoyConnection.go
@@ -68,7 +68,7 @@ func (c *connection) WriteToEnvoy(input string) {
 	if c.conn != nil {
 
 
-		_, err := c.conn.Write(append([]byte(input), []byte("\r\n")...))
+		_, err := c.conn.Write(append([]byte(input + "\r\n")))
 		if err != nil {
 			log.Printf("Could not write to Envoy: %s", err)
 			err := c.Retry()

--- a/main.go
+++ b/main.go
@@ -56,13 +56,13 @@ func main() {
 }
 
 
-func generateJSON(input telegrafJsonMetric) []byte {
+func generateJSON(input telegrafJsonMetric) string {
 
 	returnValue, err := json.Marshal(input)
 	if err != nil {
 		log.Fatal("Could not Marshal the telegrafJsonMetrics: ", err)
 	}
-	return returnValue
+	return string(returnValue)
 }
 
 var createRMANOutput monitorOutput = func(processedData []string, fileName string) {

--- a/main_test.go
+++ b/main_test.go
@@ -11,11 +11,13 @@ type TestTimeInformation struct {
 }
 
 func (t *TestTimeInformation) Now() time.Time {
-	return time.Unix(1574201685, 1574201685000).UTC() // return specific timestamp
+  var time, _ = time.Parse(time.RFC3339, "2019-11-19T22:40:59.201685Z")
+	return time
 }
 
 func (t *TestTimeInformation) getFileInformation(fileName string) time.Time {
-	return time.Unix(1574201685, 1574201685000).UTC()
+  var time, _ = time.Parse(time.RFC3339, "2019-11-19T22:40:59.201685Z")
+	return time
 }
 
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,11 +11,11 @@ type TestTimeInformation struct {
 }
 
 func (t *TestTimeInformation) Now() time.Time {
-	return time.Unix(1574201685, 1574201685000) // return specific timestamp
+	return time.Unix(1574201685, 1574201685000).UTC() // return specific timestamp
 }
 
 func (t *TestTimeInformation) getFileInformation(fileName string) time.Time {
-	return time.Unix(1574201685, 1574201685000)
+	return time.Unix(1574201685, 1574201685000).UTC()
 }
 
 
@@ -23,7 +23,7 @@ type Testconnection struct {
 	mock.Mock
 }
 
-func (t *Testconnection) WriteToEnvoy(input []byte) {
+func (t *Testconnection) WriteToEnvoy(input string) {
 	t.Called(input)
 }
 
@@ -38,7 +38,7 @@ func (t *Testconnection) Retry() error {
 
 func TestDataguardOutput(t *testing.T) {
 	testObj := new (Testconnection)
-	var byteOutput = []byte("{\"Timestamp\":\"2019-11-19T14:40:59.201685-08:00\",\"Name\":\"dataguard\",\"Tags\":null,\"Fields\":{\"file_age\":\"2019-11-19T14:40:59.201685-08:00\",\"replication\":1,\"status\":\"success\"}}")
+	var byteOutput = "{\"Timestamp\":\"2019-11-19T22:40:59.201685Z\",\"Name\":\"dataguard\",\"Tags\":null,\"Fields\":{\"file_age\":\"2019-11-19T22:40:59.201685Z\",\"replication\":1,\"status\":\"success\"}}"
 	conn = testObj
 
 	testObj.On("WriteToEnvoy", mock.Anything)
@@ -55,7 +55,7 @@ func TestRMANOutput(t *testing.T) {
 	conn = testObj
 	timestamp = new (TestTimeInformation)
 	var value = []string{"RMAN-12345","ORA-123","RMAN-456123"}
-	var byteOutput = []byte("{\"Timestamp\":\"2019-11-19T14:40:59.201685-08:00\",\"Name\":\"RMAN\",\"Tags\":null,\"Fields\":{\"error_codes\":[\"RMAN-12345\",\"ORA-123\",\"RMAN-456123\"],\"file_age\":\"2019-11-19T14:40:59.201685-08:00\",\"status\":\"success\"}}")
+	var byteOutput = "{\"Timestamp\":\"2019-11-19T22:40:59.201685Z\",\"Name\":\"RMAN\",\"Tags\":null,\"Fields\":{\"error_codes\":[\"RMAN-12345\",\"ORA-123\",\"RMAN-456123\"],\"file_age\":\"2019-11-19T22:40:59.201685Z\",\"status\":\"success\"}}"
 	testObj.On("WriteToEnvoy", mock.Anything)
 	createRMANOutput(value, "notUsed")
 
@@ -67,12 +67,11 @@ func TestTablespaceOutput(t *testing.T) {
 	conn = testObj
 	timestamp = new (TestTimeInformation)
 	var value = []string{"SYSTEM", "2.59", "SYSAUX", "3.48"}
-	var systemTableOutput = []byte("{\"Timestamp\":\"2019-11-19T14:40:59.201685-08:00\",\"Name\":\"Tablespace\",\"Tags\":{\"tablespace_name\":\"SYSTEM\"},\"Fields\":{\"file_age\":\"2019-11-19T14:40:59.201685-08:00\",\"status\":\"success\",\"usage\":\"2.59\"}}")
-	var sysauxTableOutput = []byte("{\"Timestamp\":\"2019-11-19T14:40:59.201685-08:00\",\"Name\":\"Tablespace\",\"Tags\":{\"tablespace_name\":\"SYSAUX\"},\"Fields\":{\"file_age\":\"2019-11-19T14:40:59.201685-08:00\",\"status\":\"success\",\"usage\":\"3.48\"}}")
+	var systemTableOutput = "{\"Timestamp\":\"2019-11-19T22:40:59.201685Z\",\"Name\":\"Tablespace\",\"Tags\":{\"tablespace_name\":\"SYSTEM\"},\"Fields\":{\"file_age\":\"2019-11-19T22:40:59.201685Z\",\"status\":\"success\",\"usage\":\"2.59\"}}"
+	var sysauxTableOutput = "{\"Timestamp\":\"2019-11-19T22:40:59.201685Z\",\"Name\":\"Tablespace\",\"Tags\":{\"tablespace_name\":\"SYSAUX\"},\"Fields\":{\"file_age\":\"2019-11-19T22:40:59.201685Z\",\"status\":\"success\",\"usage\":\"3.48\"}}"
 
 	testObj.On("WriteToEnvoy", mock.Anything)
 	createTablespaceOutput(value, "notUsed")
-
 	testObj.AssertCalled(t, "WriteToEnvoy", systemTableOutput)
 	testObj.AssertCalled(t, "WriteToEnvoy", sysauxTableOutput)
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-692

# What

I standardize the testing timestamp mocking to make sure its always using UTC.
For test failures it is supposed to make the output more readable than a byte[] output

# How

I made sure to append .UTC() to the end of the testing time functions

It converts a byte[] into a string to be passed through a couple functions to finally be turned back into a byte[] again to be sent across the network. 

## How to test

The tests should now pass in gcb. This can be tested locally by running
`cloud-build-local --config=cloudbuild.yml --dryrun=false .`
If you dont have cloud-build-local installed here are instructions https://cloud.google.com/cloud-build/docs/build-debug-locally

To test this you would need to alter a test to make it fail and then run the tests

# Why

Readability and understanding trumps a few extra microseconds of performance.
